### PR TITLE
Some update

### DIFF
--- a/github-create
+++ b/github-create
@@ -25,7 +25,7 @@ github-create() {
     invalid_credentials=1
   fi
 
-  if [ "$invalid_credentials" == "1" ]; then
+  if [ "$invalid_credentials" -eq "1" ]; then
     return 1
   fi
 


### PR DESCRIPTION
Avoid to memorize in the bash session the value of _invalid_credential_ to 1.
Added compatibility with zsh.
