### PR TITLE
Recommended alternate config file for GitHub token

### DIFF
--- a/github-create
+++ b/github-create
@@ -1,8 +1,8 @@
 github-create() {
-  repo_name=$1
+  local repo_name=$1
 
-  dir_name=`basename $(pwd)`
-  invalid_credentials=0
+  local dir_name=`basename $(pwd)`
+  local invalid_credentials=0
 
   if [ "$repo_name" = "" ]; then
     echo "  Repo name (hit enter to use '$dir_name')?"
@@ -13,13 +13,13 @@ github-create() {
     repo_name=$dir_name
   fi
 
-  username=`git config github.user`
+  local username=`git config github.user`
   if [ "$username" = "" ]; then
     echo "  Could not find username, run 'git config --global github.user <username>'"
     invalid_credentials=1
   fi
 
-  token=`git config github.token`
+  local token=`git config github.token`
   if [ "$token" = "" ]; then
     echo "  Could not find token, run 'mkdir -p ~/.config/git; git config --file ~/.config/git/config github.token <token>'"
     invalid_credentials=1


### PR DESCRIPTION
Since it’s pretty common to keep .gitconfig in a public repo, I changed the recommendation to use an alternate config file, that git config also reads from (see FILES in the man page).
